### PR TITLE
feat: adds some parameters to `waitForText` to act as a kill switch a…

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,12 +10,12 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,10 @@ import { KeyMap } from './keyToHEx';
 export type SpawnResult = {
     wait: (delay: number) => Promise<void>;
     waitForText: (
-        output: string
-    ) => Promise<{ line: string; type: 'stdout' | 'stderr' }>;
+        output: string,
+        timeout?: number,
+        ignoreExit?: boolean
+    ) => Promise<{ line: string; type: "output" | "timeout" | "exit" }>;
     waitForFinish: () => Promise<ExecResult>;
     writeText: (input: string) => Promise<void>;
     getStdout: () => string[];

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,6 +38,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                   "Commands:",
                   "testing-cli-entry.js print [input]  print a string",
                   "testing-cli-entry.js text           ask text input",
+                  "testing-cli-entry.js error          exit with error",
                   "testing-cli-entry.js select         ask select input",
                   "Options:",
                   "--help     Show help                                             [boolean]",
@@ -139,6 +140,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                               "Commands:",
                               "testing-cli-entry.js print [input]  print a string",
                               "testing-cli-entry.js text           ask text input",
+                              "testing-cli-entry.js error          exit with error",
                               "testing-cli-entry.js select         ask select input",
                               "Options:",
                               "--help     Show help                                             [boolean]",
@@ -240,6 +242,39 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                 ]
             ]).toContainEqual(getStdout());
             expect(getExitCode()).toBe(0);
+
+            await cleanup();
+        });
+
+        it('should ask for text and continue with process exits early', async () => {
+            const { spawn, cleanup } = await prepareEnvironment();
+
+            const {
+                waitForText,
+                writeText,
+                getStderr,
+                getExitCode,
+                waitForFinish,
+            } = await spawn('node', './test/testing-cli-entry.js error');
+
+            expect(getExitCode()).toBeNull();
+
+            await waitForText('Missing Text', 100);
+            await writeText('input');
+
+            await waitForFinish();
+
+            await waitForText('Missing Text', 10000);
+            
+            expect(getStderr()).toMatchInlineSnapshot(`
+                [
+                  "An error occurred",
+                ]
+            `);
+
+
+
+            expect(getExitCode()).toBe(1);
 
             await cleanup();
         });

--- a/test/testing-cli.ts
+++ b/test/testing-cli.ts
@@ -28,6 +28,10 @@ yargs(hideBin(process.argv))
 
         console.log(`Answered: ${number}`);
     })
+    .command('error', 'exit with error', () => {
+        console.error('An error occurred');
+        process.exit(1);
+    })
     .command('select', 'ask select input', async () => {
         const { option } = await prompts({
             type: 'select',


### PR DESCRIPTION
# Summary
- Adds `timeout` parameter to **waitForText** to provide local timeouts to individual actions. Defaults: 5000
- Adds `ignoreOnExit` parameter to **waitForText**. If true **waitForText** with continue wait after the exit code has been emitted.