### PR TITLE
feat: waitForText parameters expanded to object

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,11 @@ export type SpawnResult = {
     wait: (delay: number) => Promise<void>;
     waitForText: (
         output: string,
-        timeout?: number,
-        ignoreExit?: boolean
+        options?: Partial<{
+            timeout?: number,
+            ignoreExit?: boolean,
+            checkHistory?: boolean,
+        }>,
     ) => Promise<{ line: string; type: "found" | "timeout" | "exit" }>;
     waitForFinish: () => Promise<ExecResult>;
     writeText: (input: string) => Promise<void>;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -268,12 +268,14 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
 
             expect(await waitForText('An error occurred')).toBeFoundInOutput();
 
-            expect(await waitForText('Missing Text', 100)).queryToTimeOut();
+            expect(await waitForText('Missing Text', { timeout: 100 })).queryToTimeOut();
             await writeText('input');
 
             expect(await waitForFinish()).exitCodeToBe(1);
 
-            expect(await waitForText('Missing Text', 10000)).processToExit();
+            expect(await waitForText('Missing Text', { timeout: 10000 })).processToExit(); 
+
+            expect(await waitForText('An error occurred', { checkHistory: true })).toBeFoundInOutput();
             
             expect(getStderr()).toMatchInlineSnapshot(`
                 [


### PR DESCRIPTION
# Summary

- `waitForText` parameters `timeout` and `ignoreExit` replaced with `options`. See example below.

```ts
import { prepareEnvironment } from '@axistaylor/cli-testing-library';

const { spawn, cleanup } = await prepareEnvironment();

const {
    waitForText,
    writeText,
    getStderr,
    getExitCode,
    waitForFinish,
} = await spawn('node', './test/testing-cli-entry.js error');

expect(await waitForText('An error occurred')).toBeFoundInOutput();

expect(await waitForText('Missing Text', { timeout: 100 })).queryToTimeOut();
await writeText('input');

expect(await waitForFinish()).exitCodeToBe(1);

expect(await waitForText('Missing Text', { timeout: 10000 })).processToExit(); 

expect(await waitForText('An error occurred', { checkHistory: true })).toBeFoundInOutput();
```