### PR TITLE
feat: More time functionality added

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,9 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+import type { Config } from 'jest';
+
+const config: Config = {
     setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
     preset: 'ts-jest',
     testEnvironment: 'node',
 };
+
+export default config;

--- a/matchers/jest.ts
+++ b/matchers/jest.ts
@@ -27,12 +27,14 @@ declare global {
             queryToTimeOut(): Promise<T>;
             processToExit(): Promise<T>;
             exitCodeToBe(expected: number): Promise<T>;
+            exitCodeToBeNull(): Promise<T>;
         }
         interface ExpectExtendMap {
             toBeFoundInOutput: Matcher<TextSearchResult>;
             queryToTimeOut: Matcher<TextSearchResult>;
             processToExit: Matcher<TextSearchResult>;
             exitCodeToBe: MatcherWithParams<ProcessStats, [expected: number]>;
+            exitCodeToBeNull: Matcher<ProcessStats>;
         }
     }
 }
@@ -111,6 +113,13 @@ export const customMatchers = {
         return {
             pass,
             message: () => `Expected: ${this.utils.printExpected(expected)}\nReceived: ${this.utils.printReceived(received.code)}`
+        };
+    },
+    exitCodeToBeNull(this: jest.MatcherContext, received: ProcessStats) {
+        const pass = this.equals(received.code, null);
+        return {
+            pass,
+            message: () => `Expected: ${this.utils.printExpected(null)}\nReceived: ${this.utils.printReceived(received.code)}`
         };
     },
 };

--- a/src/createExecute.ts
+++ b/src/createExecute.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os';
 import path from 'path';
 
 export type ExitCode = 0 | 1;
-export type ExecResult = { code: ExitCode; stdout: string[]; stderr: string[] };
+export type ExecResult = { code: ExitCode | null; stdout: string[]; stderr: string[] };
 export const createExecute =
     (
         base: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,8 @@ export type CLITestEnvironment = {
     execute: (
         runner: string,
         command: string,
-        runFrom?: string
+        runFrom?: string,
+        timeout?: number,
     ) => Promise<ExecResult>;
     spawn: (
         runner: string,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,18 +8,27 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
         it('runs with multiple runners', async () => {
             const { execute, cleanup } = await prepareEnvironment();
 
-            const { code } = await execute(
+            expect(await execute(
                 'node',
                 './test/testing-cli-entry.js --help'
-            );
+            )).exitCodeToBe(0);
 
-            const { code: code2 } = await execute(
+            expect(await execute(
                 'ts-node',
                 './test/testing-cli.ts --help'
-            );
+            )).exitCodeToBe(0);
 
-            expect(code2).toBe(0);
-            expect(code).toBe(0);
+            expect(await execute(
+                'ts-node',
+                './test/testing-cli.ts error'
+            )).exitCodeToBe(1);
+
+            expect(await execute(
+                'ts-node',
+                './test/testing-cli.ts wait',
+                undefined,
+                1000,
+            )).exitCodeToBeNull();
 
             await cleanup();
         });
@@ -41,6 +50,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                   "testing-cli-entry.js text           ask text input",
                   "testing-cli-entry.js error          exit with error",
                   "testing-cli-entry.js select         ask select input",
+                  "testing-cli-entry.js wait           wait for 5 seconds",
                   "Options:",
                   "--help     Show help                                             [boolean]",
                   "--version  Show version number                                   [boolean]",
@@ -66,7 +76,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
             const end = new Date();
             const delay = end.getTime() - start.getTime();
 
-            await waitForFinish();
+            expect(await waitForFinish()).exitCodeToBe(0);
 
             expect(delay).toBeGreaterThan(990);
             expect(delay).toBeLessThan(1010);
@@ -92,7 +102,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                   "Second",
                 ]
             `);
-            expect(getExitCode()).toBe(null);
+            expect(getExitCode()).toBeNull();
 
             await cleanup();
         });
@@ -107,9 +117,9 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                 './test/testing-cli-entry.js --help'
             );
 
-            await waitForFinish();
+            expect(await waitForFinish()).exitCodeToBe(0);
 
-            expect(process.stdout.write).not.toBeCalled();
+            expect(process.stdout.write).not.toHaveBeenCalled();
 
             const { debug, waitForFinish: waitForFinishOnceMore } = await spawn(
                 'node',
@@ -118,9 +128,9 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
 
             debug();
 
-            await waitForFinishOnceMore();
+            expect(await waitForFinishOnceMore()).exitCodeToBe(0);
 
-            expect(process.stdout.write).toBeCalled();
+            expect(process.stdout.write).toHaveBeenCalled();
 
             await cleanup();
         });
@@ -143,6 +153,7 @@ describe('Tests testing the CLI and so, the testing lib itself', () => {
                               "testing-cli-entry.js text           ask text input",
                               "testing-cli-entry.js error          exit with error",
                               "testing-cli-entry.js select         ask select input",
+                              "testing-cli-entry.js wait           wait for 5 seconds",
                               "Options:",
                               "--help     Show help                                             [boolean]",
                               "--version  Show version number                                   [boolean]",

--- a/test/testing-cli.ts
+++ b/test/testing-cli.ts
@@ -45,6 +45,10 @@ yargs(hideBin(process.argv))
 
         console.log(`Picked: ${option}`);
     })
+    .command('wait', 'wait for 5 seconds', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        console.log('Done waiting');
+    })
     .option('verbose', {
         alias: 'v',
         type: 'boolean',


### PR DESCRIPTION
# Summary

- Adds `timeout` parameter to `execute` 
- Adds `exitCodeToBeNull` matcher. See example below

```ts
expect(await execute(
    'ts-node',
    './test/testing-cli.ts wait',
    undefined,
    1000,
)).exitCodeToBeNull();
```
